### PR TITLE
Mirror subject.name.strategy from Java client

### DIFF
--- a/confluent_kafka/avro/__init__.py
+++ b/confluent_kafka/avro/__init__.py
@@ -2,6 +2,7 @@
     Avro schema registry module: Deals with encoding and decoding of messages with avro schemas
 
 """
+import pkg_resources
 
 from confluent_kafka import Producer, Consumer
 from confluent_kafka.avro.error import ClientError
@@ -36,10 +37,27 @@ class AvroProducer(Producer):
         elif schema_registry_url is not None:
             raise ValueError("Cannot pass schema_registry along with schema.registry.url config")
 
+        self._serializer = MessageSerializer(schema_registry,
+                                             self._load_name_strategy(config, "value.subject.name.strategy"),
+                                             self._load_name_strategy(config, "key.subject.name.strategy"))
+
         super(AvroProducer, self).__init__(config)
-        self._serializer = MessageSerializer(schema_registry)
         self._key_schema = default_key_schema
         self._value_schema = default_value_schema
+
+    @staticmethod
+    def _load_name_strategy(config, key):
+        strategy_name = config.pop(key, "TopicName")
+        subject_name_strategy_plugins = {
+            entry_point.name: entry_point
+            for entry_point
+            in pkg_resources.iter_entry_points('subject.name.strategy')
+        }
+        subject_name_strategy = subject_name_strategy_plugins.get(strategy_name, None)
+        if subject_name_strategy is None:
+            raise ValueError("The subject name strategy plugin named {} could not be found.".format(
+                strategy_name))
+        return subject_name_strategy.load()()
 
     def produce(self, **kwargs):
         """

--- a/confluent_kafka/avro/serializer/name_strategies.py
+++ b/confluent_kafka/avro/serializer/name_strategies.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+A set of common Subject naming strategies for use with the Confluent Schema Registry.  The built-in strategies mirror
+the strategies provided via the Java client (https://github.com/confluentinc/schema-registry).
+
+The built in strategies include:
+``TopicName``
+  The topic name is used along with either "key" or "value".
+
+``RecordName``
+  The fully-qualified name of the avro schema is used.
+
+``TopicRecordName``
+  The topic name is used along with the fully-qualified name of the avro schema.
+
+Additional strategies may be provided at run time by registering a class with the ``subject.name.strategy`` entry
+point.
+
+"""
+
+
+class SubjectNameStrategy(object):
+    """
+    A {@link SubjectNameStrategy} is used by the Avro serializer to determine
+    the subject name under which the event record schemas should be registered
+    in the schema registry. The default is {@link TopicNameStrategy}.
+    """
+    def get_subject_name(self, topic, is_key, schema):
+        """
+        For a given topic and message, returns the subject name under which the
+        schema should be registered in the schema registry.
+        :param topic: The Kafka topic name to which the message is being published.
+        :param is_key: True when encoding a message key, false for a message value.
+        :param schema: The value to be published in the message.
+        :return: The subject name under which the schema should be registered.
+        """
+        raise NotImplemented("SubjectNameStrategy implementations must implement get_subject_name.")
+
+
+class TopicNameStrategy(SubjectNameStrategy):
+    """
+    Default {@link SubjectNameStrategy}: for any messages published to
+    `topic`, the schema of the message key is registered under
+    the subject name `topic`-key, and the message value is registered
+    under the subject name `topic`-value.
+    """
+    def get_subject_name(self, topic, is_key, schema):
+        suffix = "-key" if is_key else "-value"
+        return topic + suffix
+
+
+class RecordNameStrategy(SubjectNameStrategy):
+    """
+    For any Avro record type that is published to Kafka, registers the schema
+    in the registry under the fully-qualified record name (regardless of the
+    topic). This strategy allows a topic to contain a mixture of different
+    record types, since no intra-topic compatibility checking is performed.
+    Instead, checks compatibility of any occurrences of the same record name
+    across `all` topics.
+    """
+    def get_subject_name(self, topic, is_key, schema):
+        return schema.fullname
+
+
+class TopicRecordNameStrategy(RecordNameStrategy):
+    """
+    For any Avro record type that is published to Kafka topic `topic`,
+    registers the schema in the registry under the subject name
+    `topic`-`recordName`, where `recordName` is the
+    fully-qualified Avro record name. This strategy allows a topic to contain
+    a mixture of different record types, since no intra-topic compatibility
+    checking is performed. Moreover, different topics may contain mutually
+    incompatible versions of the same record name, since the compatibility
+    check is scoped to a particular record name within a particular topic.
+    """
+    def get_subject_name(self, topic, is_key, schema):
+        return topic + "-" + RecordNameStrategy.get_subject_name(self, topic, is_key, schema)

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,11 @@ setup(name='confluent-kafka',
       extras_require={
           'avro': ['fastavro', 'requests', avro],
           'dev': get_install_requirements("test-requirements.txt")
+      },
+      entry_points={
+          'subject.name.strategy': [
+              'TopicName = confluent_kafka.avro.serializer.name_strategies:TopicNameStrategy [avro]',
+              'RecordName = confluent_kafka.avro.serializer.name_strategies:RecordNameStrategy [avro]',
+              'TopicRecordName = confluent_kafka.avro.serializer.name_strategies:TopicRecordNameStrategy [avro]'
+          ]
       })

--- a/tests/avro/mock_schema_registry_client.py
+++ b/tests/avro/mock_schema_registry_client.py
@@ -27,7 +27,7 @@ class MockSchemaRegistryClient(object):
     """
     A client that acts as a schema registry locally.
 
-    Compatibiity related methods are not implemented at this time.
+    Compatibility related methods are not implemented at this time.
     """
 
     def __init__(self, max_schemas_per_subject=1000):

--- a/tests/avro/test_subject_name_strategies.py
+++ b/tests/avro/test_subject_name_strategies.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from avro.schema import Names, RecordSchema
+
+import confluent_kafka.avro.serializer.name_strategies as strategies
+from confluent_kafka.avro import AvroProducer
+from tests.avro.mock_schema_registry_client import MockSchemaRegistryClient
+
+
+class TestMessageSerializer(unittest.TestCase):
+    def test_topic_name(self):
+        strategy = strategies.TopicNameStrategy()
+        topic = "some_legal_topic_name"
+        expected = topic + "-key"
+        actual = strategy.get_subject_name(topic, True, None)
+        assert expected == actual
+        expected = topic + "-value"
+        actual = strategy.get_subject_name(topic, False, None)
+        assert expected == actual
+
+    def test_record_name(self):
+        strategy = strategies.RecordNameStrategy()
+        schema = RecordSchema("MyRecordType", "my.namespace", fields=[], names=Names())
+        expected = "my.namespace.MyRecordType"
+        actual = strategy.get_subject_name(None, None, schema)
+        assert expected == actual
+
+    def test_topic_record_name(self):
+        strategy = strategies.TopicRecordNameStrategy()
+        topic = "some_legal_topic_name"
+        schema = RecordSchema("MyRecordType", "my.namespace", fields=[], names=Names())
+        expected = "some_legal_topic_name-my.namespace.MyRecordType"
+        actual = strategy.get_subject_name(topic, None, schema)
+        assert expected == actual
+
+    def test_default_subject_name_strategy(self):
+        schema_registry = MockSchemaRegistryClient()
+        producer = AvroProducer(config={}, schema_registry=schema_registry)
+        serializer = producer._serializer
+        assert isinstance(serializer.key_subject_name_strategy, strategies.TopicNameStrategy)
+        assert isinstance(serializer.value_subject_name_strategy, strategies.TopicNameStrategy)
+
+    def test_explicit_topic_subject_name_strategy(self):
+        schema_registry = MockSchemaRegistryClient()
+        config = {
+            'value.subject.name.strategy': 'TopicName',
+            'key.subject.name.strategy': 'TopicName'
+        }
+        producer = AvroProducer(config=config, schema_registry=schema_registry)
+        serializer = producer._serializer
+        assert isinstance(serializer.key_subject_name_strategy, strategies.TopicNameStrategy)
+        assert isinstance(serializer.value_subject_name_strategy, strategies.TopicNameStrategy)
+
+    def test_explicit_record_subject_name_strategy(self):
+        schema_registry = MockSchemaRegistryClient()
+        config = {
+            'value.subject.name.strategy': 'RecordName',
+            'key.subject.name.strategy': 'RecordName'
+        }
+        producer = AvroProducer(config=config, schema_registry=schema_registry)
+        serializer = producer._serializer
+        assert isinstance(serializer.key_subject_name_strategy, strategies.RecordNameStrategy)
+        assert isinstance(serializer.value_subject_name_strategy, strategies.RecordNameStrategy)
+
+    def test_explicit_topic_record_subject_name_strategy(self):
+        schema_registry = MockSchemaRegistryClient()
+        config = {
+            'value.subject.name.strategy': 'TopicRecordName',
+            'key.subject.name.strategy': 'TopicRecordName'
+        }
+        producer = AvroProducer(config=config, schema_registry=schema_registry)
+        serializer = producer._serializer
+        assert isinstance(serializer.key_subject_name_strategy, strategies.TopicRecordNameStrategy)
+        assert isinstance(serializer.value_subject_name_strategy, strategies.TopicRecordNameStrategy)
+
+    def test_differing_key_and_value_subject_name_strategies(self):
+        schema_registry = MockSchemaRegistryClient()
+        config = {
+            'value.subject.name.strategy': 'RecordName',
+            'key.subject.name.strategy': 'TopicRecordName'
+        }
+        producer = AvroProducer(config=config, schema_registry=schema_registry)
+        serializer = producer._serializer
+        assert isinstance(serializer.key_subject_name_strategy, strategies.RecordNameStrategy)
+        assert isinstance(serializer.value_subject_name_strategy, strategies.TopicRecordNameStrategy)


### PR DESCRIPTION
Provides a means to configure a subject name strategy for both key and value when using
the schema registry.  This brings the python client in line with the java client, and
enables the use of multiple schemas on a single topic.